### PR TITLE
feat: add mcp() hook to install ArgoCD MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+p6df module for ArgoCD: GitOps CLI tools (`argocd`, `argocd-autopilot`) and
+MCP server (`@modelcontextprotocol/server-argocd`) for AI-driven GitOps workflows.
 
 ## Contributing
 
@@ -37,6 +38,7 @@ TODO: Add a short summary of this module.
 
 - `p6df::modules::argocd::deps()`
 - `p6df::modules::argocd::external::brew()`
+- `p6df::modules::argocd::mcp()`
 - `str info = p6df::modules::argocd::prompt::mod()`
 
 ## Hierarchy

--- a/init.zsh
+++ b/init.zsh
@@ -32,6 +32,20 @@ p6df::modules::argocd::external::brew() {
 ######################################################################
 #<
 #
+# Function: p6df::modules::argocd::mcp()
+#
+#>
+######################################################################
+p6df::modules::argocd::mcp() {
+
+  p6_js_npm_global_install "@modelcontextprotocol/server-argocd"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
 # Function: str info = p6df::modules::argocd::prompt::mod()
 #
 #  Returns:


### PR DESCRIPTION
## Summary

- `mcp()`: installs `@modelcontextprotocol/server-argocd` for AI-driven GitOps workflows
- No `mcp::env()` needed: no profile management for ArgoCD; server and auth token
  configured externally via `ARGOCD_SERVER` and `ARGOCD_AUTH_TOKEN`

## Test plan

- [ ] `p6df mcp p6df-argocd` installs `@modelcontextprotocol/server-argocd`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)