### PR TITLE
fix: use correct argocd-mcp package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
 
 ## Summary
 
-p6df module for ArgoCD: GitOps CLI tools (`argocd`, `argocd-autopilot`) and
-MCP server (`@modelcontextprotocol/server-argocd`) for AI-driven GitOps workflows.
+p6df module for ArgoCD: CLI tools (`argocd`), profile switching, and MCP
+server (`argocd-mcp`) for AI-driven GitOps application management.
 
 ## Contributing
 

--- a/init.zsh
+++ b/init.zsh
@@ -38,7 +38,7 @@ p6df::modules::argocd::external::brew() {
 ######################################################################
 p6df::modules::argocd::mcp() {
 
-  p6_js_npm_global_install "@modelcontextprotocol/server-argocd"
+  p6_js_npm_global_install "argocd-mcp"
 
   p6_return_void
 }


### PR DESCRIPTION
## Summary

- Fix `mcp()` hook: replace `@modelcontextprotocol/server-argocd` (incorrect) with `argocd-mcp` (the actual npm package for the ArgoCD MCP server)

## Test plan

- [ ] `p6df mcp` installs `argocd-mcp` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)