### PR TITLE
feat: add gitops-workflows Claude skill to deps

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -10,6 +10,7 @@ p6df::modules::argocd::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-kubernetes
     ohmyzsh/ohmyzsh:plugins/argocd
+    ahmedasmar/devops-claude-skills:gitops-workflows
   )
 }
 


### PR DESCRIPTION
## Summary
- Added `ahmedasmar/devops-claude-skills:gitops-workflows` to `ModuleDeps` in `init.zsh`
- Enables GitOps workflow Claude skill for ArgoCD module users

## Test plan
- [ ] Verify `ModuleDeps` array includes the new skill entry
- [ ] Confirm shell syntax is valid (`shellcheck init.zsh`)
- [ ] Test module loads without errors in a p6df environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)