### PR TITLE
feat: add home::symlinks() for claude skills

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -17,6 +17,21 @@ p6df::modules::argocd::deps() {
 ######################################################################
 #<
 #
+# Function: p6df::modules::argocd::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR
+#>
+######################################################################
+p6df::modules::argocd::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_DIR/ahmedasmar/devops-claude-skills/gitops-workflows"  "$HOME/.claude/skills/gitops-workflows"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
 # Function: p6df::modules::argocd::external::brew()
 #
 #>


### PR DESCRIPTION
## Summary

- Adds `home::symlinks()` function to symlink Claude Code skills into `~/.claude/skills/`

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)