### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -32,11 +32,11 @@ p6df::modules::argocd::home::symlinks() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::argocd::external::brew()
+# Function: p6df::modules::argocd::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::argocd::external::brew() {
+p6df::modules::argocd::external::brews() {
 
   p6df::core::homebrew::cli::brew::install argocd
   p6df::core::homebrew::cli::brew::install argocd-autopilot


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly