### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -75,5 +75,5 @@ p6df::modules::argocd::mcp() {
 ######################################################################
 p6df::modules::argocd::profile::mod() {
 
-  p6_return_words 'argocd' '$KUBECONFIG'
+  p6_return_words 'argocd' "$"
 }

--- a/init.zsh
+++ b/init.zsh
@@ -65,17 +65,15 @@ p6df::modules::argocd::mcp() {
 ######################################################################
 #<
 #
-# Function: str info = p6df::modules::argocd::prompt::mod()
+# Function: words argocd = p6df::modules::argocd::profile::mod()
 #
 #  Returns:
-#	str - info
+#	words - argocd
 #
+#  Environment:	 KUBECONFIG
 #>
 ######################################################################
-p6df::modules::argocd::prompt::mod() {
+p6df::modules::argocd::profile::mod() {
 
-  #  local info="argocd:"
-  local info=""
-
-  p6_return_str "$info"
+  p6_return_words 'argocd' '$KUBECONFIG'
 }


### PR DESCRIPTION
## What
Refactor prompt module with all local changes including p6_return_words quoting fix.

## Why
Split p6_return_words word and variable into separate quoted args; also includes related prompt/profile refactors.

## Test plan
- Verified diff contains expected changes

## Dependencies
None