### PR TITLE
refactor(module): remove unused home symlinks and profile mod functions

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -17,21 +17,6 @@ p6df::modules::argocd::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::argocd::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_DIR
-#>
-######################################################################
-p6df::modules::argocd::home::symlinks() {
-
-  p6_file_symlink "$P6_DFZ_SRC_DIR/ahmedasmar/devops-claude-skills/gitops-workflows"  "$HOME/.claude/skills/gitops-workflows"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
 # Function: p6df::modules::argocd::external::brews()
 #
 #>
@@ -60,20 +45,4 @@ p6df::modules::argocd::mcp() {
   p6df::modules::openai::mcp::server::add "argocd" "npx" "-y" "argocd-mcp"
 
   p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: words argocd = p6df::modules::argocd::profile::mod()
-#
-#  Returns:
-#	words - argocd
-#
-#  Environment:	 KUBECONFIG
-#>
-######################################################################
-p6df::modules::argocd::profile::mod() {
-
-  p6_return_words 'argocd' "$"
 }


### PR DESCRIPTION
## What
Remove two dead-code functions from `init.zsh`:
- `p6df::modules::argocd::home::symlinks()` — symlink to `gitops-workflows` that is no longer needed
- `p6df::modules::argocd::profile::mod()` — returned a placeholder `$` string with no value

## Why
These functions are unused stubs/dead code. Removing them reduces maintenance surface and avoids confusion from functions that returned meaningless placeholder values.

## Test plan
- Reviewed diff manually
- No callers of these functions exist in this module

## Dependencies
None